### PR TITLE
Support WASM components

### DIFF
--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -19,6 +19,9 @@ pub enum WSError {
     #[error("Ed25519 signature function error")]
     CryptoError(#[from] ed25519_compact::Error),
 
+    #[error("Unsupported module type")]
+    UnsupportedModuleType,
+
     #[error("No valid signatures")]
     VerificationFailed,
 

--- a/src/lib/src/signature/simple.rs
+++ b/src/lib/src/signature/simple.rs
@@ -74,6 +74,7 @@ impl PublicKey {
         reader: &mut impl Read,
         detached_signature: Option<&[u8]>,
     ) -> Result<(), WSError> {
+        let _header = Module::stream_init(reader)?;
         let mut sections = Module::stream(reader)?;
 
         // Read the signature header from the module, or reconstruct it from the detached signature.

--- a/src/lib/src/split.rs
+++ b/src/lib/src/split.rs
@@ -58,6 +58,7 @@ impl Module {
             }
         }
         Ok(Module {
+            header: self.header,
             sections: out_sections,
         })
     }


### PR DESCRIPTION
I looked at the changes of 1f49b998e65b6645da03eb9f584ed2ed05e54427 (that were subsequently reverted by 8bb3638894ea24076d01fea3bc6fe9cc9ad14ef7) and made a functionning version of component support by following the same procedures. 

If there was a reason other than the non-functionning part why this was reverted, please let me know. I tested signing and verifying a standard WASM module and a component and everything seems to work as expected!