### PR TITLE
Publicly export `SignatureData` and its related types.

### DIFF
--- a/src/lib/src/signature/mod.rs
+++ b/src/lib/src/signature/mod.rs
@@ -11,6 +11,7 @@ pub use matrix::*;
 pub use multi::*;
 #[allow(unused_imports)]
 pub use simple::*;
+pub use sig_sections::{SignatureData, SignedHashes, SignatureForHashes};
 
 pub(crate) use hash::*;
 pub(crate) use sig_sections::*;


### PR DESCRIPTION
`SignatureData` is used in the return type of the public [`CustomSection::signature_data`] function, so make it public to allow this function to be used.

This type is also useful for deserializing signatures from wasm binaries in order to obtain their key id fields.

[`CustomSection::signature_data`]: https://docs.rs/wasmsign2/latest/wasmsign2/struct.CustomSection.html#method.signature_data