### PR TITLE
Trim unused depenencies.

### DIFF
--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -12,13 +12,11 @@ repository = "https://github.com/wasm-signatures/wasmsign2"
 categories = ["cryptography", "wasm"]
 
 [dependencies]
-anyhow = "1.0.100"
 ct-codecs = "1.1.6"
 ed25519-compact = { version = "2.1.1", features = ["pem"] }
 getrandom = { version = "0.3.4", features = ["wasm_js"] }
 hmac-sha256 = "1.1.12"
 log = "0.4.28"
-regex = "1.12.2"
 ssh-keys = "0.1.4"
 thiserror = "2.0.17"
 

--- a/src/lib/src/lib.rs
+++ b/src/lib/src/lib.rs
@@ -21,7 +21,7 @@ pub use split::*;
 pub use wasm_module::*;
 
 pub mod reexports {
-    pub use {anyhow, ct_codecs, getrandom, hmac_sha256, log, regex, thiserror};
+    pub use {ct_codecs, getrandom, hmac_sha256, log, thiserror};
 }
 
 const SIGNATURE_WASM_DOMAIN: &str = "wasmsig";


### PR DESCRIPTION
wasmsign2 doesn't use regex or anyhow, so it doesn't need to depend on and re-export them. This allows downstream users to avoid pulling them in as dependencies if they aren't otherwise needed.