### PR TITLE
Remove `signature` from the .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ Cargo.lock
 *.wasm
 *.key
 *.key2
-signature
 src/lib/target
 wasmsign2


### PR DESCRIPTION
The path `src/lib/src/signature` appears to contain source files, so it doesn't seem like it should be ignored by git.